### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Bluum est un jeu web contemplatif où des formes de vie abstraites évoluent dan
 
 * Créer un **jeu web addictif mais apaisant** (type tamagotchi cosmique)
 * Basé sur l’émergence visuelle et l’évolution génétique
-* Jouable en navigateur, supportant une persistence serveur
+* Jouable en navigateur, supportant une persistance serveur
 * Rendu en **3D isométrique low-poly** via Three.js
 
 ---


### PR DESCRIPTION
## Summary
- fix a typo in the project objectives

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68435797f84c83309e38591ee1421dac