### PR TITLE
Fix spawnOffspring with browser crypto.randomUUID

### DIFF
--- a/src/evolution.js
+++ b/src/evolution.js
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 
 export function simulateGeneration(entities, environment) {
   return entities.map(e => {
@@ -12,7 +11,7 @@ export function simulateGeneration(entities, environment) {
 
     const reproduces = Math.random() > 0.8;
     if (reproduces) {
-      return [e, { ...e, id: randomUUID(), genes: { ...e.genes } }];
+      return [e, { ...e, id: crypto.randomUUID(), genes: { ...e.genes } }];
     }
 
     return e;
@@ -24,7 +23,7 @@ export function spawnOffspring(parent) {
   const offspring = JSON.parse(JSON.stringify(parent));
 
   // Assign a new unique ID
-  offspring.id = randomUUID();
+  offspring.id = crypto.randomUUID();
 
   // Slightly mutate each numeric gene (\u00b110%)
   for (const key of Object.keys(offspring.genes)) {


### PR DESCRIPTION
## Summary
- remove Node `crypto` import
- call `crypto.randomUUID()` directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435ad2c9488330ac48d6aff91e5972