### PR TITLE
Visible reproduction loop + basic population cap

### DIFF
--- a/src/evolution.js
+++ b/src/evolution.js
@@ -1,21 +1,25 @@
 
 export function simulateGeneration(entities, environment) {
-  return entities.map(e => {
-    const survives = Math.random() > 0.1;
-    if (!survives) return null;
+  let next = [];
+  for (const entity of entities) {
+    entity.age = (entity.age ?? 0) + 1;
+    next.push(entity);
 
-    const mutated = Math.random() < e.genes.mutationRate;
-    if (mutated) {
-      e.genes.size += (Math.random() - 0.5) * 0.2;
+    if (Math.random() < 0.2) {
+      const offspring = spawnOffspring(entity);
+      offspring.age = 0;
+      next.push(offspring);
     }
+  }
 
-    const reproduces = Math.random() > 0.8;
-    if (reproduces) {
-      return [e, { ...e, id: crypto.randomUUID(), genes: { ...e.genes } }];
-    }
+  if (next.length > 50) {
+    const killCount = Math.floor(next.length * 0.1);
+    const sorted = [...next].sort((a, b) => b.age - a.age);
+    const toRemove = new Set(sorted.slice(0, killCount).map(e => e.id));
+    next = next.filter(e => !toRemove.has(e.id));
+  }
 
-    return e;
-  }).flat().filter(Boolean);
+  return next;
 }
 
 export function spawnOffspring(parent) {

--- a/test/evolution.test.js
+++ b/test/evolution.test.js
@@ -2,34 +2,45 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { simulateGeneration } from '../src/evolution.js';
 
-test('simulateGeneration returns entities array without nulls and generates id', () => {
-  const values = [0.5, 0, 0.5, 0.9];
+// Verify that offspring is created when probability threshold is met
+test('simulateGeneration spawns offspring', () => {
+  const values = [0.1];
   let i = 0;
   const originalRandom = Math.random;
   Math.random = () => values[i++] ?? 0.5;
 
-  let generatedId;
   const originalUUID = crypto.randomUUID;
-  crypto.randomUUID = () => {
-    generatedId = 'new-id';
-    return generatedId;
-  };
+  crypto.randomUUID = () => 'child-id';
 
-  const parent = {
-    id: 'p1',
-    position: { x: 0, y: 0 },
-    genes: { size: 1, mutationRate: 0.1 }
-  };
+  const parent = { id: 'p1', position: { x: 0, y: 0 }, genes: { size: 1 } };
 
   const result = simulateGeneration([parent], {});
 
   Math.random = originalRandom;
   crypto.randomUUID = originalUUID;
 
-  assert.ok(Array.isArray(result), 'result should be an array');
-  assert.ok(result.every(e => e !== null), 'no null entries');
-  assert.equal(result.length, 2, 'reproduction adds an offspring');
-  const offspring = result.find(e => e.id === generatedId);
-  assert.ok(offspring, 'offspring with generated ID exists');
+  assert.equal(result.length, 2, 'one offspring added');
+  assert.ok(result.some(e => e.id === 'child-id'), 'offspring present');
+  const parentOut = result.find(e => e.id === 'p1');
+  assert.equal(parentOut.age, 1, 'parent age incremented');
 });
 
+// Population cap should remove oldest individuals
+test('simulateGeneration caps population over 50', () => {
+  const originalRandom = Math.random;
+  Math.random = () => 0.5; // never spawn
+
+  const entities = Array.from({ length: 51 }, (_, i) => ({
+    id: `e${i}`,
+    position: { x: 0, y: 0 },
+    genes: {},
+    age: i
+  }));
+
+  const result = simulateGeneration(entities, {});
+
+  Math.random = originalRandom;
+
+  assert.equal(result.length, 46, '10% oldest removed');
+  assert.ok(!result.some(e => e.id === 'e50'), 'oldest entity removed');
+});


### PR DESCRIPTION
## Summary
- implement new simulateGeneration logic
- update world init and update loop to show reproduction
- track entity meshes for spawn & death
- test reproduction chance and population cap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843d85d36f483308591b7a7522bedc4