### PR TITLE
HUD pixel-art (stats temps réel)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <title>Bluum</title>
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/src/hud.css">
   </head>
   <body>
+    <div id="hud"></div>
     <canvas id="world"></canvas>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/src/data.js
+++ b/src/data.js
@@ -1,6 +1,7 @@
 export const initialEntities = [
   {
     id: 'e1',
+    speciesId: 's1',
     position: { x: 0, y: 0 },
     genes: {
       size: 0.5,

--- a/src/evolution.js
+++ b/src/evolution.js
@@ -1,6 +1,18 @@
 
+const stats = {
+  tick: 0,
+  entities: 0,
+  species: 0,
+  deaths: []
+};
+
+export function getStats() {
+  return stats;
+}
+
 export function simulateGeneration(entities, environment) {
   let next = [];
+  const deaths = [];
   for (const entity of entities) {
     entity.age = (entity.age ?? 0) + 1;
     next.push(entity);
@@ -16,8 +28,19 @@ export function simulateGeneration(entities, environment) {
     const killCount = Math.floor(next.length * 0.1);
     const sorted = [...next].sort((a, b) => b.age - a.age);
     const toRemove = new Set(sorted.slice(0, killCount).map(e => e.id));
-    next = next.filter(e => !toRemove.has(e.id));
+    next = next.filter(e => {
+      if (toRemove.has(e.id)) {
+        deaths.push(e.id);
+        return false;
+      }
+      return true;
+    });
   }
+
+  stats.tick++;
+  stats.entities = next.length;
+  stats.species = new Set(next.map(e => e.speciesId)).size;
+  stats.deaths = deaths;
 
   return next;
 }
@@ -28,6 +51,8 @@ export function spawnOffspring(parent) {
 
   // Assign a new unique ID
   offspring.id = crypto.randomUUID();
+
+  offspring.speciesId = parent.speciesId;
 
   // Slightly mutate each numeric gene (\u00b110%)
   for (const key of Object.keys(offspring.genes)) {

--- a/src/hud.css
+++ b/src/hud.css
@@ -1,0 +1,12 @@
+#hud {
+  position: fixed;
+  top: 0;
+  left: 0;
+  font-family: 'Press Start 2P', 'VT323', monospace;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid #555;
+  padding: 6px;
+  color: #fff;
+  text-shadow: 1px 1px #000;
+  pointer-events: none;
+}

--- a/src/hud.js
+++ b/src/hud.js
@@ -1,0 +1,9 @@
+export function updateHUD({ tick, entities, species, deaths }) {
+  const hud = document.getElementById('hud');
+  if (!hud) return;
+  let html = `Tick: ${tick}<br>Entities: ${entities}<br>Species: ${species}`;
+  if (deaths && deaths.length) {
+    html += `<br>Deaths: ${deaths.join(', ')}`;
+  }
+  hud.innerHTML = html;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { initWorld, updateWorld } from './world.js';
+import { updateHUD } from './hud.js';
+import { getStats } from './evolution.js';
 
 console.log("Bluum is alive");
 const scene = new THREE.Scene();
@@ -33,6 +35,7 @@ animate();
 function animate() {
   requestAnimationFrame(animate);
   updateWorld();
+  updateHUD(getStats());
   controls.update();
   renderer.render(scene, camera);
 }


### PR DESCRIPTION
## Summary
- add pixel-art HUD with Press Start 2P/VT323 fonts
- expose evolution stats through `getStats`
- track tick, populations, species and deaths
- display realtime stats on screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843dd6320188330baea25d4ade71ddf