### PR TITLE
Add tempo slider

### DIFF
--- a/src/hud.css
+++ b/src/hud.css
@@ -11,3 +11,24 @@
   text-shadow: 1px 1px #000;
   pointer-events: none;
 }
+
+#sliderContainer {
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: monospace;
+  font-size: 8px;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid #555;
+  padding: 2px 4px;
+  color: #fff;
+}
+
+#sliderContainer input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 8px;
+  height: 8px;
+  background: #aaa;
+  cursor: pointer;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { initWorld, updateWorld } from './world.js';
 import { updateHUD } from './hud.js';
 import { getStats } from './evolution.js';
+import { initTempoSlider } from './tempoSlider.js';
 
 console.log("Bluum is alive");
 const scene = new THREE.Scene();
@@ -30,11 +31,19 @@ window.addEventListener('resize', () => {
 });
 
 initWorld(scene);
+let tickInterval = 1000;
+let tickTimer = setInterval(updateWorld, tickInterval);
+
+initTempoSlider((newMs) => {
+  clearInterval(tickTimer);
+  tickInterval = newMs;
+  tickTimer = setInterval(updateWorld, tickInterval);
+});
+
 animate();
 
 function animate() {
   requestAnimationFrame(animate);
-  updateWorld();
   updateHUD(getStats());
   controls.update();
   renderer.render(scene, camera);

--- a/src/tempoSlider.js
+++ b/src/tempoSlider.js
@@ -1,0 +1,26 @@
+export function initTempoSlider(onChange) {
+  const container = document.createElement('div');
+  container.id = 'sliderContainer';
+
+  const input = document.createElement('input');
+  input.type = 'range';
+  input.id = 'tempo';
+  input.min = '100';
+  input.max = '2000';
+  input.value = '1000';
+  input.step = '100';
+
+  const label = document.createElement('span');
+  label.id = 'tempoLabel';
+  label.textContent = 'Tick: 1.0 s';
+
+  container.appendChild(input);
+  container.appendChild(label);
+  document.body.appendChild(container);
+
+  input.addEventListener('input', () => {
+    const ms = Number(input.value);
+    label.textContent = `Tick: ${(ms / 1000).toFixed(1)} s`;
+    onChange(ms);
+  });
+}

--- a/src/world.js
+++ b/src/world.js
@@ -57,8 +57,6 @@ function noise2D(x, y) {
 let entities = [...initialEntities];
 let worldScene;
 const entityMeshes = new Map();
-let lastGeneration = Date.now();
-const GENERATION_INTERVAL = 5000;
 
 // Palette rétro de 32 couleurs (verts ternes, bruns, gris roche)
 const RETRO_PALETTE = [
@@ -209,9 +207,6 @@ export function initWorld(scene) {
 }
 
 export function updateWorld() {
-  const now = Date.now();
-  if (now - lastGeneration < GENERATION_INTERVAL) return;
-  lastGeneration = now;
 
   const beforeIds = new Set(entities.map(e => e.id));
   entities = simulateGeneration(entities, {});


### PR DESCRIPTION
## Summary
- add tempoSlider.js to render a HUD range input for tick speed
- style the slider in hud.css
- integrate slider and tick timer setup in main.js
- remove generation timing checks in world.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843e2a90c30833094f003726b703d41