### PR TITLE
Edge spawn rejection

### DIFF
--- a/src/hud.js
+++ b/src/hud.js
@@ -1,7 +1,8 @@
-export function updateHUD({ tick, entities, species, deaths }) {
+export function updateHUD({ tick, entities, species, deaths, edgeRejects }) {
   const hud = document.getElementById('hud');
   if (!hud) return;
   let html = `Tick: ${tick}<br>Entities: ${entities}<br>Species: ${species}`;
+  html += `<br>Edge rejects: ${edgeRejects}`;
 
   if (deaths && deaths.length) {
     const recent = deaths.slice(-5);


### PR DESCRIPTION
## Summary
- track edge rejects in the simulation stats
- clamp offspring spawn position away from edges
- surface new metric in the HUD

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843e5032214833092f4151ed6fb8de3