### PR TITLE
🕹️ Session controls (new, pause, end)

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -1,0 +1,35 @@
+export function initControls(onNew, onTogglePause, onEnd) {
+  const container = document.createElement('div');
+  container.id = 'controls';
+
+  const newBtn = document.createElement('button');
+  newBtn.className = 'pixel';
+  newBtn.textContent = 'NEW';
+
+  const pauseBtn = document.createElement('button');
+  pauseBtn.className = 'pixel';
+  pauseBtn.textContent = 'PAUSE';
+
+  const endBtn = document.createElement('button');
+  endBtn.className = 'pixel';
+  endBtn.textContent = 'END';
+
+  newBtn.addEventListener('click', () => {
+    onNew();
+    pauseBtn.textContent = 'PAUSE';
+  });
+
+  pauseBtn.addEventListener('click', () => {
+    const paused = onTogglePause();
+    pauseBtn.textContent = paused ? 'PLAY' : 'PAUSE';
+  });
+
+  endBtn.addEventListener('click', () => {
+    onEnd();
+  });
+
+  container.appendChild(newBtn);
+  container.appendChild(pauseBtn);
+  container.appendChild(endBtn);
+  document.body.appendChild(container);
+}

--- a/src/hud.css
+++ b/src/hud.css
@@ -32,3 +32,36 @@
   background: #aaa;
   cursor: pointer;
 }
+
+#controls {
+  position: fixed;
+  bottom: 24px;
+  left: 0;
+  padding: 4px;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid #555;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+}
+
+#controls .pixel {
+  background: #111;
+  color: #fff;
+  border: 1px solid #555;
+  margin-right: 2px;
+  padding: 2px 4px;
+  cursor: pointer;
+}
+
+#hudPause {
+  position: fixed;
+  top: 0;
+  right: 0;
+  font-family: 'VT323', monospace;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid #555;
+  padding: 4px;
+  color: #fff;
+  text-shadow: 1px 1px #000;
+  display: none;
+}

--- a/src/hud.js
+++ b/src/hud.js
@@ -1,6 +1,15 @@
+import { isWorldPaused, getEndSummary } from './world.js';
+
 export function updateHUD({ tick, entities, species, deaths, edgeRejects }) {
   const hud = document.getElementById('hud');
   if (!hud) return;
+
+  const summary = getEndSummary();
+  if (summary) {
+    hud.innerHTML = `Ticks: ${summary.ticks}<br>Pop max: ${summary.popMax}<br>Species: ${summary.species}`;
+    return;
+  }
+
   let html = `Tick: ${tick}<br>Entities: ${entities}<br>Species: ${species}`;
   html += `<br>Edge rejects: ${edgeRejects}`;
 
@@ -13,4 +22,13 @@ export function updateHUD({ tick, entities, species, deaths, edgeRejects }) {
   }
 
   hud.innerHTML = html;
+
+  let pause = document.getElementById('hudPause');
+  if (!pause) {
+    pause = document.createElement('div');
+    pause.id = 'hudPause';
+    document.body.appendChild(pause);
+  }
+  pause.textContent = '⏸ PAUSE';
+  pause.style.display = isWorldPaused() ? 'block' : 'none';
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,10 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { initWorld, updateWorld } from './world.js';
+import { initWorld, newGame, togglePause, endGame, setTickInterval } from './world.js';
 import { updateHUD } from './hud.js';
 import { getStats } from './evolution.js';
 import { initTempoSlider } from './tempoSlider.js';
+import { initControls } from './controls.js';
 
 console.log("Bluum is alive");
 const scene = new THREE.Scene();
@@ -31,14 +32,13 @@ window.addEventListener('resize', () => {
 });
 
 initWorld(scene);
-let tickInterval = 1000;
-let tickTimer = setInterval(updateWorld, tickInterval);
+newGame();
 
 initTempoSlider((newMs) => {
-  clearInterval(tickTimer);
-  tickInterval = newMs;
-  tickTimer = setInterval(updateWorld, tickInterval);
+  setTickInterval(newMs);
 });
+
+initControls(newGame, togglePause, endGame);
 
 animate();
 


### PR DESCRIPTION
## Summary
- add pixel HUD controls for new game, pause/play and end
- allow adjusting tick interval through new world functions
- show pause indicator and end-game summary in HUD
- manage game state via new functions in world module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843eb7964b883308f4e4af9da645f3d