### PR TITLE
Node backend + WebSocket sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
-        "three": "^0.177.0"
+        "three": "^0.177.0",
+        "ws": "^8.17.0",
+        "better-sqlite3": "^9.1.0"
       },
       "devDependencies": {
         "vite": "^6.3.5"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "type": "module",
   "dependencies": {
     "express": "^5.1.0",
-    "three": "^0.177.0"
+    "three": "^0.177.0",
+    "ws": "^8.17.0",
+    "better-sqlite3": "^9.1.0"
   },
   "devDependencies": {
     "vite": "^6.3.5"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,41 @@
+import express from 'express';
+import { WebSocketServer } from 'ws';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { initWorld, simulateGeneration, getDelta, getWorld } from './src/serverWorld.js';
+import { saveWorld, loadWorld } from './src/db.js';
+
+const PORT = 3000;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const app = express();
+app.use(express.static(__dirname));
+
+const server = app.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});
+
+const wss = new WebSocketServer({ server });
+const clients = new Set();
+
+wss.on('connection', ws => {
+  clients.add(ws);
+  ws.send(JSON.stringify({ type: 'init', data: getDelta() }));
+  ws.on('close', () => clients.delete(ws));
+});
+
+const saved = loadWorld();
+initWorld(saved);
+
+setInterval(() => {
+  const delta = simulateGeneration();
+  const msg = JSON.stringify({ type: 'delta', data: delta });
+  for (const ws of clients) {
+    if (ws.readyState === ws.OPEN) ws.send(msg);
+  }
+}, 1000);
+
+setInterval(() => {
+  saveWorld(getWorld());
+}, 30000);

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,20 @@
+import Database from 'better-sqlite3';
+
+const db = new Database('bluum.db');
+
+db.exec(`CREATE TABLE IF NOT EXISTS world (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  data TEXT
+)`);
+
+export function saveWorld(world) {
+  const stmt = db.prepare(
+    'INSERT INTO world (id, data) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET data = excluded.data'
+  );
+  stmt.run(JSON.stringify(world));
+}
+
+export function loadWorld() {
+  const row = db.prepare('SELECT data FROM world WHERE id = 1').get();
+  return row ? JSON.parse(row.data) : null;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { initWorld, newGame, togglePause, endGame, setTickInterval, setEnergyMax } from './world.js';
+import { initWorld, newGame, togglePause, endGame, setTickInterval, setEnergyMax, applyDelta } from './world.js';
 import { updateHUD } from './hud.js';
 import { getStats } from './evolution.js';
 import { initTempoSlider } from './tempoSlider.js';
@@ -33,7 +33,19 @@ window.addEventListener('resize', () => {
 });
 
 initWorld(scene);
-newGame();
+const useWS = window.location.protocol.startsWith('ws');
+if (useWS) {
+  const ws = new WebSocket(`${window.location.protocol}//${window.location.host}`);
+  ws.addEventListener('message', (ev) => {
+    const msg = JSON.parse(ev.data);
+    if (msg.data) applyDelta(msg.data);
+  });
+  ws.addEventListener('close', () => {
+    newGame();
+  });
+} else {
+  newGame();
+}
 
 initTempoSlider((newMs) => {
   setTickInterval(newMs);

--- a/src/serverWorld.js
+++ b/src/serverWorld.js
@@ -1,0 +1,49 @@
+import { initialEntities } from './data.js';
+import { simulateGeneration as evolve } from './evolution.js';
+import { params } from './params.js';
+
+const GRID_SIZE = 15;
+let entities = [];
+let energyMap = [];
+
+function initEnergyMap() {
+  energyMap = Array.from({ length: GRID_SIZE }, () =>
+    Array.from({ length: GRID_SIZE }, () =>
+      params.energyMax / 2 + Math.random() * (params.energyMax / 2)
+    )
+  );
+}
+
+function regenEnergy() {
+  for (let x = 0; x < GRID_SIZE; x++) {
+    for (let z = 0; z < GRID_SIZE; z++) {
+      energyMap[x][z] = Math.min(
+        params.energyMax,
+        energyMap[x][z] + params.regen
+      );
+    }
+  }
+}
+
+export function initWorld(saved) {
+  if (saved) {
+    ({ entities, energyMap } = saved);
+  } else {
+    entities = JSON.parse(JSON.stringify(initialEntities));
+    initEnergyMap();
+  }
+}
+
+export function simulateGeneration() {
+  regenEnergy();
+  entities = evolve(entities, { energyMap });
+  return getDelta();
+}
+
+export function getDelta() {
+  return { entities };
+}
+
+export function getWorld() {
+  return { entities, energyMap };
+}

--- a/src/world.js
+++ b/src/world.js
@@ -346,3 +346,10 @@ export function isWorldPaused() {
 export function getEndSummary() {
   return endSummary;
 }
+
+export function applyDelta(delta) {
+  if (Array.isArray(delta.entities)) {
+    entities = delta.entities;
+    updateInstances(entities.slice(0, MAX_INSTANCES));
+  }
+}


### PR DESCRIPTION
## Summary
- add simple Node server exposing WebSocket updates
- persist world to sqlite
- support remote deltas on client
- expose server-side world helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684412bb354c8330b40f9677ce968325